### PR TITLE
Return the sort cursor along the document 

### DIFF
--- a/guillotina_elasticsearch/utility.py
+++ b/guillotina_elasticsearch/utility.py
@@ -132,6 +132,9 @@ class ElasticSearchUtility(ElasticSearchManager):
                 '@absolute_url': container_url + data.get('path', ''),
                 '@type': data.get('type_name'),
             })
+            sort_value = item.get('sort')
+            if sort_value:
+                data.update({'sort': sort_value})
             items.append(data)
         final = {
             'items_count': result['hits']['total'],


### PR DESCRIPTION
Return the sort cursor along the document  to be used with the ES search_after parameter

https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-search-after.html