### PR TITLE
Fix TIDConflictError when registry is edited during a migration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 1.1.18 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix TIDConflictError when registry is edited during a migration.
+  [vangheem]
 
 
 1.1.17 (2017-08-11)

--- a/guillotina_elasticsearch/manager.py
+++ b/guillotina_elasticsearch/manager.py
@@ -265,6 +265,11 @@ class ElasticSearchManager(DefaultSearchUtility):
         registry._p_register()
 
     async def apply_next_index(self, container, request=None):
+        # make sure to reload the registry to make sure we have the latest
+        # to write to
+        if (request is not None and hasattr(request, 'container_settings') and
+                REGISTRY_DATA_KEY in container.__annotations__):
+            await request._txn.refresh(request.container_settings)
         registry = await self.get_registry(container, request)
         assert registry['el_next_index_version'] is not None
         await self.set_version(


### PR DESCRIPTION
This would happen when registry is edited in the middle of a migration