### PR TITLE
Prevent more than one index_field define different mappings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 3.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Prevent more than one index_field define different mappings
+  [masipcat]
 
 
 3.1.0 (2018-11-20)

--- a/guillotina_elasticsearch/schema.py
+++ b/guillotina_elasticsearch/schema.py
@@ -70,6 +70,14 @@ def get_mappings(schemas=None, schema_info=False):
                     field_mapping['_schemas'] = []
                 if schema.__identifier__ not in field_mapping['_schemas']:
                     field_mapping['_schemas'].append(schema.__identifier__)
+
+            if index_name in mappings and mappings[index_name] != field_mapping:
+                raise Exception(
+                    f'Index "{index_name}" of schema "{schema}" is trying to '
+                    f'overwrite existing mapping "{mappings[index_name]}" '
+                    f'with "{field_mapping}"'
+                )
+
             mappings[index_name] = field_mapping
 
     return {

--- a/guillotina_elasticsearch/tests/test_schema.py
+++ b/guillotina_elasticsearch/tests/test_schema.py
@@ -1,0 +1,21 @@
+from guillotina.schema import Int, Float
+from guillotina.directives import index_field
+from guillotina_elasticsearch.schema import get_mappings
+from zope.interface import Interface
+
+import pytest
+
+
+class IA(Interface):
+    index_field('item', field_mapping={'type': 'integer'})
+    item = Int()
+
+
+class IB(Interface):
+    index_field('item', field_mapping={'type': 'float'})
+    item = Float()
+
+
+async def test_get_mappings_fails_on_conflict():
+    with pytest.raises(Exception):
+        get_mappings(schemas=[IA, IB])

--- a/guillotina_elasticsearch/tests/test_schema.py
+++ b/guillotina_elasticsearch/tests/test_schema.py
@@ -16,6 +16,22 @@ class IB(Interface):
     item = Float()
 
 
+class IC(Interface):
+    index_field('item', field_mapping={'type': 'float'})
+    item = Float()
+
+
 async def test_get_mappings_fails_on_conflict():
     with pytest.raises(Exception):
+        # Two content types define DIFFERENT mapping for same field ->
+        #   conflict!
         get_mappings(schemas=[IA, IB])
+
+
+async def test_get_mappings_nofails():
+    try:
+        # Two content types define SAME mapping for same field ->
+        #   everything is ok
+        get_mappings(schemas=[IB, IC])
+    except Exception:
+        pytest.fail("get_mappings() shouldn't fail if 'field_mapping' are the same")


### PR DESCRIPTION
Implements point 2 of https://github.com/guillotinaweb/guillotina_elasticsearch/issues/43#issuecomment-442126316