### PR TITLE
[master] Changed 'query.bool.filter' to use a list instead of a single object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 5.0.0a3 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- build_security_query(): changed 'query.bool.filter' to use a list instead of a single object
+  [masipcat]
 
 
 5.0.0a2 (2019-06-21)

--- a/guillotina_elasticsearch/queries.py
+++ b/guillotina_elasticsearch/queries.py
@@ -27,12 +27,14 @@ async def build_security_query(container):
     return {
         'query': {
             'bool': {
-                'filter': {
-                    'bool': {
-                        'should': should_list,
-                        'minimum_should_match': 1
+                'filter': [
+                    {
+                        'bool': {
+                            'should': should_list,
+                            'minimum_should_match': 1
+                        }
                     }
-                }
+                ]
             }
         }
     }


### PR DESCRIPTION
I'm using the `query()` method of `IElasticSearchUtility` and when I do a query like
```
{"query": {
  "bool": {
    "filter": [ ... ]
    }
  }
}
```
`utility.query()` crashes because can't merge the input query with the query that adds Guillotina