### PR TITLE
[3.3.x] Changed 'query.bool.filter' to use a list instead of a single object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 3.3.14 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- build_security_query(): changed 'query.bool.filter' to use a list instead of a single object
+  [masipcat]
 
 
 3.3.13 (2019-09-03)

--- a/guillotina_elasticsearch/queries.py
+++ b/guillotina_elasticsearch/queries.py
@@ -28,12 +28,14 @@ async def build_security_query(container):
     return {
         'query': {
             'bool': {
-                'filter': {
-                    'bool': {
-                        'should': should_list,
-                        'minimum_should_match': 1
+                'filter': [
+                    {
+                        'bool': {
+                            'should': should_list,
+                            'minimum_should_match': 1
+                        }
                     }
-                }
+                ]
             }
         }
     }


### PR DESCRIPTION
Same as https://github.com/plone/guillotina_elasticsearch/pull/59