### PR TITLE
Changed es_requester fixture to only cleanup indices that match 'index_name_prefix'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 6.0.0a3 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Changed es_requester fixture to only cleanup indices that match 'index_name_prefix'
 
 
 6.0.0a2 (2020-05-12)

--- a/guillotina_elasticsearch/tests/fixtures.py
+++ b/guillotina_elasticsearch/tests/fixtures.py
@@ -1,3 +1,4 @@
+from guillotina import app_settings
 from guillotina import testing
 from guillotina.component import get_utility
 from guillotina.interfaces import ICatalogUtility
@@ -65,8 +66,6 @@ class ESRequester(ContainerRequesterAsyncContextManager):
         await util.close(search.loop)
         search.loop = self.loop
 
-        from guillotina import app_settings
-
         if os.environ.get("TESTING", "") == "jenkins":
             if "elasticsearch" in app_settings:
                 app_settings["elasticsearch"]["connection_settings"][
@@ -84,5 +83,5 @@ class ESRequester(ContainerRequesterAsyncContextManager):
 async def es_requester(elasticsearch, guillotina, event_loop):
     # clean up all existing indexes
     es_host = "{}:{}".format(elasticsearch[0], elasticsearch[1])
-    await cleanup_es(es_host)
+    await cleanup_es(es_host, app_settings["elasticsearch"]["index_name_prefix"])
     return ESRequester(guillotina, event_loop)


### PR DESCRIPTION
This is useful when running pytest with xdist and each process runs on a different index_name. Otherwise all processes delete other processes' indices 