### PR TITLE
- Add query options search_type and preference

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 3.3.26 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add query options search_type and preference
 
 
 3.3.25 (2020-01-30)

--- a/guillotina_elasticsearch/utility.py
+++ b/guillotina_elasticsearch/utility.py
@@ -230,7 +230,13 @@ class ElasticSearchUtility(DefaultSearchUtility):
 
     async def query(
             self, container, query,
-            doc_type=None, size=10, request=None, scroll=None, index=None):
+            doc_type=None, 
+            size=10, 
+            request=None, 
+            scroll=None, 
+            index=None,
+            search_type=None,
+            preference=None):
         """
         transform into query...
         right now, it's just passing through into elasticsearch
@@ -246,6 +252,11 @@ class ElasticSearchUtility(DefaultSearchUtility):
         q = await self._build_security_query(
             container, query, doc_type, size, scroll)
         q['ignore_unavailable'] = True
+
+        if search_type:
+            q["search_type"] = search_type
+        if preference:
+            q["preference"] = preference
 
         conn = self.get_connection()
 


### PR DESCRIPTION
These options allow us to target specific shards and get consistent scores/results on multiple submissions of the same query

https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-search-type.html