### PR TITLE
replacing _from to from in Parser's __call__

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 6.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Replacing _from to from in Parser's __call__ [nilbacardit26]
 
 
 6.0.0 (2020-07-10)

--- a/guillotina_elasticsearch/parser.py
+++ b/guillotina_elasticsearch/parser.py
@@ -88,30 +88,39 @@ def process_field(field, value):
     index = get_index_definition(field)
     if index is None:
         return
-
-    if len(value) > 1:
-        term_keyword = "terms"
-        if not isinstance(value, list):
-            value = [value]
-    else:
-        term_keyword = "term"
-        if isinstance(value, list):
-            value = value[0]
-
     _type = index["type"]
-    if _type == "int":
-        try:
-            value = int(value)
-        except ValueError:
-            pass
-    elif _type == "date":
-        value = parse(value).timestamp()
-
-    elif _type == "boolean":
-        if value in ("true", "True", "yes"):
-            value = True
+    if not isinstance(value, list):
+        value = [value]
+        term_keyword = "term"
+    else:
+        if len(value) > 1:
+            term_keyword = "terms"
         else:
-            value = False
+            term_keyword = "term"
+    result_list = []
+    for value_list in value:
+        value_cast = None
+        if _type == "int":
+            try:
+                value_cast = int(value_list)
+            except ValueError:
+                pass
+        elif _type == "date":
+            value_cast = parse(value_list).timestamp()
+
+        elif _type == "boolean":
+            if value in ("true", "True", "yes"):
+                value_cast = True
+            else:
+                value_cast = False
+        if value_cast:
+            result_list.append(value_cast)
+        else:
+            result_list.append(value_list)
+    if len(result_list) == 1:
+        value = result_list[0]
+    else:
+        value = result_list
 
     if modifier is None:
         # Keyword we expect an exact match

--- a/guillotina_elasticsearch/parser.py
+++ b/guillotina_elasticsearch/parser.py
@@ -109,10 +109,10 @@ def process_field(field, value):
             value_cast = parse(value_list).timestamp()
 
         elif _type == "boolean":
-            if value in ("true", "True", "yes"):
-                value_cast = True
+            if value_list in ("true", "True", "yes", True):
+                value_cast = "true"
             else:
-                value_cast = False
+                value_cast = "false"
         if value_cast:
             result_list.append(value_cast)
         else:

--- a/guillotina_elasticsearch/tests/test_custom_index.py
+++ b/guillotina_elasticsearch/tests/test_custom_index.py
@@ -67,8 +67,10 @@ async def test_indexes_data_in_correct_indexes(es_requester):
             ),
         )
         assert status == 201
-        content_index_name = "guillotina-db-guillotina__uniqueindexcontent-{}".format(  # noqa
-            get_short_uid(cresp["@uid"])
+        content_index_name = (
+            "guillotina-db-guillotina__uniqueindexcontent-{}".format(  # noqa
+                get_short_uid(cresp["@uid"])
+            )
         )
         search = get_utility(ICatalogUtility)
 
@@ -110,8 +112,10 @@ async def test_elastic_index_field(es_requester):
                 }
             ),
         )
-        content_index_name = "guillotina-db-guillotina__uniqueindexcontent-{}".format(  # noqa
-            get_short_uid(cresp["@uid"])
+        content_index_name = (
+            "guillotina-db-guillotina__uniqueindexcontent-{}".format(  # noqa
+                get_short_uid(cresp["@uid"])
+            )
         )
         search = get_utility(ICatalogUtility)
 
@@ -154,8 +158,10 @@ async def test_delete_resource(es_requester):
             ),
         )
         assert status == 201
-        content_index_name = "guillotina-db-guillotina__uniqueindexcontent-{}".format(  # noqa
-            get_short_uid(cresp["@uid"])
+        content_index_name = (
+            "guillotina-db-guillotina__uniqueindexcontent-{}".format(  # noqa
+                get_short_uid(cresp["@uid"])
+            )
         )
         search = get_utility(ICatalogUtility)
 
@@ -212,8 +218,10 @@ async def test_delete_base_removes_index_from_elastic(es_requester):
         )
         catalog = get_utility(ICatalogUtility)
         await requester("DELETE", "/db/guillotina/foobar")
-        content_index_name = "guillotina-db-guillotina__uniqueindexcontent-{}".format(  # noqa
-            get_short_uid(cresp["@uid"])
+        content_index_name = (
+            "guillotina-db-guillotina__uniqueindexcontent-{}".format(  # noqa
+                get_short_uid(cresp["@uid"])
+            )
         )
 
         async def _test():

--- a/guillotina_elasticsearch/tests/test_parser.py
+++ b/guillotina_elasticsearch/tests/test_parser.py
@@ -30,3 +30,13 @@ async def _test_es_field_parser(dummy_guillotina):
     assert "depth" in qq[1]["range"]
     assert "lte" in qq[1]["range"]["depth"]
     assert qq[1]["range"]["depth"]["lte"] == 10
+
+
+async def test_parser(dummy_guillotina):
+    content = test_utils.create_content()
+    parser = Parser(None, content)
+    params = {'depth__gte': '2', 'type_name': 'Item'}
+    query = parser(params)
+    qq = query["query"]["bool"]["must"]
+    assert "_from" not in query
+    assert "Item" in qq[1]["terms"]["type_name"]

--- a/guillotina_elasticsearch/tests/test_parser.py
+++ b/guillotina_elasticsearch/tests/test_parser.py
@@ -1,5 +1,8 @@
+from guillotina.directives import index_field
+from guillotina.interfaces import IContainer
 from guillotina.tests import utils as test_utils
 from guillotina_elasticsearch.parser import Parser
+from guillotina_elasticsearch.tests.utils import setup_txn_on_container
 
 import pytest
 
@@ -7,7 +10,25 @@ import pytest
 pytestmark = [pytest.mark.asyncio]
 
 
-async def test_es_field_date_parser(dummy_guillotina):
+async def test_boolean_field(es_requester):
+    async with es_requester as requester:
+
+        @index_field.with_accessor(IContainer, "foo_bool", type="boolean")
+        def index_bool(obj):
+            return True
+
+        container, request, txn, tm = await setup_txn_on_container(requester)  # noqa
+        params = {"depth__gte": "1", "type_name": "IItem", "foo_bool": True}
+        parser = Parser(None, container)
+        query = parser(params)
+        qq = query["query"]["bool"]["must"]
+        assert "_from" not in query
+        assert qq[1]["term"]["type_name"] == "IItem"
+        # https://www.elastic.co/guide/en/elasticsearch/reference/current/boolean.html
+        assert qq[2]["term"]["foo_bool"] == "true"
+
+
+def test_es_field_date_parser(dummy_guillotina):
     content = test_utils.create_content()
     parser = Parser(None, content)
 
@@ -31,15 +52,15 @@ async def test_es_field_date_parser(dummy_guillotina):
     assert qq[1]["range"]["depth"]["lte"] == 10
 
 
-async def test_parser_term_and_terms(dummy_guillotina):
+def test_parser_term_and_terms(dummy_guillotina):
     content = test_utils.create_content()
     parser = Parser(None, content)
-    params = {'depth__gte': '2', 'type_name': 'Item'}
+    params = {"depth__gte": "2", "type_name": "Item"}
     query = parser(params)
     qq = query["query"]["bool"]["must"]
     assert "_from" not in query
     assert qq[1]["term"]["type_name"] == "Item"
-    params = {'depth__gte': '2', 'type_name': ['Item', 'Folder']}
+    params = {"depth__gte": "2", "type_name": ["Item", "Folder"]}
     query = parser(params)
     qq = query["query"]["bool"]["must"]
     assert "Item" in qq[1]["terms"]["type_name"]

--- a/guillotina_elasticsearch/tests/test_vacuum.py
+++ b/guillotina_elasticsearch/tests/test_vacuum.py
@@ -148,8 +148,10 @@ async def test_vacuum_with_sub_indexes(es_requester):
         )  # noqa
 
         search = get_utility(ICatalogUtility)
-        content_index_name = "guillotina-db-guillotina__uniqueindexcontent-{}".format(  # noqa
-            get_short_uid(cresp["@uid"])
+        content_index_name = (
+            "guillotina-db-guillotina__uniqueindexcontent-{}".format(  # noqa
+                get_short_uid(cresp["@uid"])
+            )
         )
         container, request, txn, tm = await setup_txn_on_container(requester)
         task_vars.request.set(request)

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ test_requires = [
     "coverage",
     "pytest-cov",
     "pytest-docker-fixtures[pg]>=1.3.0",
+    "prometheus-client>=0.9.0"
 ]
 
 


### PR DESCRIPTION
The `from` key made the queries to the ES fail when using the ES parser