### PR TITLE
fixing date parser, using strict_date_optional_time format

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,9 @@
 7.0.0a3 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Fixing the date parser, using arrow to parse the date. Using the default format
+  strict_date_optional_time instead of using the epoch_millis that leads
+  to the error: failed to parse date field [1.624173663E9].
 
 
 7.0.0a2 (2021-06-09)

--- a/guillotina_elasticsearch/parser.py
+++ b/guillotina_elasticsearch/parser.py
@@ -118,7 +118,7 @@ def process_field(field, value):
             except ValueError:
                 pass
         elif _type == "date":
-            value_cast = parse(value_list).timestamp()
+            value_cast = parse(value_list).isoformat()
 
         elif _type == "boolean":
             if value_list in ("true", "True", "yes", True):

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "elasticsearch[async]>=7.8.0,<8.0.0",
         "mypy_extensions",
         "lru-dict",
-        "backoff",
+        "backoff"
     ],
     tests_require=test_requires,
     extras_require={"test": test_requires},


### PR DESCRIPTION
The actual date parser leads to an error:
```
elasticsearch.exceptions.RequestError: RequestError(400, 'search_phase_execution_exception', 'failed to parse date field [1.624177188E9] with format [strict_date_optional_time||epoch_millis]: [failed to parse date field [1.624177188E9] with format [strict_date_optional_time||epoch_millis]]')
```
This is because the timestamp method used by parse includes a dot in the timestamp. Use the format of the strict_date_optional_time instead; the parser of arrow is used.

The filter has a granularity of seconds