### PR TITLE
search within the same context using the actual parser

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,10 @@
 7.0.0a4 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Adding path as a wildcard in the parser. Searches will be done
+  within the same context using the endpoint @search. FYI: If no depth is
+  specified, the query resolves greater or equal than the content depth of the context plus one
+  [nilbacardit26]
 
 
 7.0.0a3 (2021-06-22)

--- a/guillotina_elasticsearch/parser.py
+++ b/guillotina_elasticsearch/parser.py
@@ -96,6 +96,9 @@ def process_field(field, value):
     elif field.endswith("__wildcard"):
         modifier = "wildcard"
         field = field[: -len("__wildcard")]
+    elif field.endswith("__starts"):
+        modifier = "starts"
+        field = field[: -len("__starts")]
 
     index = get_index_definition(field)
     if index is None:
@@ -151,6 +154,8 @@ def process_field(field, value):
         return match_type, {"range": {field: {modifier: value}}}
     elif modifier == "wildcard":
         return match_type, {"wildcard": {field: value}}
+    elif modifier == "starts":
+        return match_type, {"wildcard": {field: f"{value}*"}}
     else:
         logger.warn(
             "wrong search type: %s modifier: %s field: %s value: %s"

--- a/guillotina_elasticsearch/tests/test_parser.py
+++ b/guillotina_elasticsearch/tests/test_parser.py
@@ -42,9 +42,8 @@ async def test_es_field_date_parser(dummy_guillotina):
             "_sort_asc": "modification_date",
         }
     )
-
     qq = parsed["query"]["bool"]["must"]
-    assert len(qq[-1]["bool"]["should"]) == 4
+    assert len(qq[-2]["bool"]["should"]) == 4
 
     assert "range" in qq[0]
     assert "modification_date" in qq[0]["range"]
@@ -67,6 +66,12 @@ async def test_parser_term_and_terms(dummy_guillotina):
     qq = query["query"]["bool"]["must"]
     assert "Item" in qq[1]["terms"]["type_name"]
     assert "Folder" in qq[1]["terms"]["type_name"]
+    # Check that b_start and b_size work as expected
+    # https://github.com/plone/guillotina_elasticsearch/issues/93
+    params = {"b_start": 5, "b_size": 10}
+    query = parser(params)
+    assert query["from"] == 5
+    assert query["size"] == 10
 
 
 async def test_parser_or_operator(es_requester):


### PR DESCRIPTION
Adding path as a wildcard in the parser. Searches will be done within the same context using the endpoint @search. FYI: If no depth is specified, the query resolves greater or equal than the content depth of the context plus one