### PR TITLE
ElasticSearchUtility: removed obsolete methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@
 - ElasticSearchUtility: removed obsolete methods get_by_uuid(), get_by_uuids(),
   get_by_type() and get_by_type()
   [masipcat]
+. ElasticSearchUtility: removed unused internal method _get_type_query()
 
 
 7.0.0a5 (2021-07-30)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@
 - ElasticSearchUtility: removed obsolete methods get_by_uuid(), get_by_uuids(),
   get_by_type() and get_by_type()
   [masipcat]
-. ElasticSearchUtility: removed unused internal method _get_type_query()
+- ElasticSearchUtility: removed unused internal method _get_type_query()
+  [masipcat]
 
 
 7.0.0a5 (2021-07-30)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,9 @@
 7.0.0a6 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- ElasticSearchUtility: removed obsolete methods get_by_uuid(), get_by_uuids(),
+  get_by_type() and get_by_type()
+  [masipcat]
 
 
 7.0.0a5 (2021-07-30)

--- a/guillotina_elasticsearch/utility.py
+++ b/guillotina_elasticsearch/utility.py
@@ -311,13 +311,6 @@ class ElasticSearchUtility(DefaultSearchUtility):
         obj = await navigate_to(container, path)
         return obj
 
-    def _get_type_query(self, doc_type):
-        query = {"query": {"bool": {"must": []}}}
-
-        if doc_type is not None:
-            query["query"]["bool"]["must"].append({"term": {"type_name": doc_type}})
-        return query
-
     async def get_path_query(self, resource, response=noop_response):
         if isinstance(resource, str):
             path = resource


### PR DESCRIPTION
These methods were removed from the default catalog interface in guillotina 5.0 ([chagelog](https://github.com/plone/guillotina/blob/caa0ba163ebc1bc913f8f47aa4171b90fead81a6/docs/source/migration/5.0.rst#api-removalschanges))