### PR TITLE
Adapt guillotina_elasticserach code to guillotina 6.4 breaking changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 7.0.0a8 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Adapt guillotina_elasticserach code to guillotina 6.4 breaking changes
+  [masipcat]
 
 
 7.0.0a7 (2021-09-14)

--- a/guillotina_elasticsearch/migration.py
+++ b/guillotina_elasticsearch/migration.py
@@ -306,9 +306,10 @@ class Migrator:
         return new_definitions
 
     async def process_folder(self, ob):
+        txn = get_current_transaction()
         for key in await ob.async_keys():
             try:
-                item = await ob.__txn__.get_child(ob, key)
+                item = await txn.get_child(ob, key)
             except (KeyError, ModuleNotFoundError):
                 continue
             if item is None:


### PR DESCRIPTION
This is needed to support https://github.com/plone/guillotina/pull/1160