### PR TITLE
Adding update_catalog coroutine to add mappings and put settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,11 @@
 7.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Adding update_catalog coroutine to the utility to add new mappings
+  and add/update settings from catalog. Changes in the guillotina's
+  schemas when fields/mappings are added, will be added automatically
+  to the mappings.
+  [nilbacardit26]
 
 
 7.0.2 (2022-11-23)
@@ -19,7 +23,7 @@
 
 - Being able to build mappings properties with analyzers
   [nilbacardit26]
-
+  
 
 7.0.0 (2022-03-16)
 ------------------

--- a/guillotina_elasticsearch/tests/test_catalog.py
+++ b/guillotina_elasticsearch/tests/test_catalog.py
@@ -5,6 +5,8 @@ from guillotina.tests.utils import create_content
 from guillotina_elasticsearch.interfaces import IIndexManager
 from guillotina_elasticsearch.tests.utils import setup_txn_on_container
 
+import asyncio
+import json
 import pytest
 
 
@@ -60,3 +62,143 @@ async def test_delete(es_requester):
         await search.remove(container, [ob])
         await search.refresh(container)
         assert await search.get_doc_count(container) == current_count
+
+
+@pytest.mark.app_settings(
+    {
+        "applications": [
+            "guillotina",
+            "guillotina_elasticsearch",
+            "guillotina_elasticsearch.tests.test_package",
+        ]
+    }
+)
+async def test_update_catalog_mappings_settings(es_requester):
+    async with es_requester as requester:
+        container, request, txn, tm = await setup_txn_on_container(requester)  # noqa
+        search = get_utility(ICatalogUtility)
+        index_manager = get_adapter(container, IIndexManager)
+        real_index_name = await index_manager.get_real_index_name()
+        conn = search.get_connection()
+        mappings_es = await conn.indices.get_mapping(index=real_index_name)
+        settings_es = await conn.indices.get_settings(index=real_index_name)
+        analysis_settings = settings_es[real_index_name]["settings"]["index"][
+            "analysis"
+        ]
+        # Makes sure that a custom index field from a cutsom guillotina
+        # app is added to the mappings
+        assert (
+            mappings_es[real_index_name]["mappings"]["properties"]["item_text"]["type"]
+            == "text"
+        )
+        assert analysis_settings["analyzer"]["common_analyzer"]["filter"] == [
+            "lowercase",
+            "asciifolding",
+        ]
+        # Let's add a new mapping rule
+        new_mappings = {
+            "properties": {"foo_new_mapping": {"type": "text", "store": True}}
+        }
+        # Let's modify all the filters for analyzers and normalizers and add a new one: common_analyzer2
+        new_settings = {
+            "index": {
+                "analysis": {
+                    "analyzer": {
+                        "common_analyzer": {
+                            "tokenizer": "standard",
+                            "char_filter": [],
+                            "filter": ["asciifolding"],
+                        },
+                        "common_analyzer2": {
+                            "tokenizer": "standard",
+                            "char_filter": [],
+                            "filter": ["asciifolding"],
+                        },
+                    },
+                    "normalizer": {
+                        "common_normalizer": {
+                            "type": "custom",
+                            "char_filter": [],
+                            "filter": ["asciifolding"],
+                        }
+                    },
+                }
+            }
+        }
+        payload = {"settings": new_settings, "mappings": new_mappings}
+        await search.update_catalog(container, payload)
+        new_mappings_es = await conn.indices.get_mapping(index=real_index_name)
+        new_settings_es = await conn.indices.get_settings(index=real_index_name)
+        new_analysis_settings = new_settings_es[real_index_name]["settings"]["index"][
+            "analysis"
+        ]
+        # Makes sure all changes had been done
+        assert (
+            new_mappings_es[real_index_name]["mappings"]["properties"][
+                "foo_new_mapping"
+            ]["type"]
+            == "text"
+        )
+        assert new_analysis_settings["analyzer"]["common_analyzer"]["filter"] == [
+            "asciifolding"
+        ]
+        assert new_analysis_settings["analyzer"]["common_analyzer2"]["filter"] == [
+            "asciifolding"
+        ]
+        assert new_analysis_settings["normalizer"]["common_normalizer"]["filter"] == [
+            "asciifolding"
+        ]
+        assert (
+            "tokenizer"
+            in new_settings_es[real_index_name]["settings"]["index"]["analysis"]
+        )
+        # Makes sure that older mappings are not deleted
+        for mapping in mappings_es[real_index_name]["mappings"]["properties"]:
+            assert mapping in new_mappings_es[real_index_name]["mappings"]["properties"]
+        # Makes sure foo_new_mapping has been added
+        assert new_mappings_es[real_index_name]["mappings"]["properties"][
+            "foo_new_mapping"
+        ] == {"type": "text", "store": True}
+
+        # Makes sure that custom mappings and settings are preserved
+        # when calling update without payload
+        await search.update_catalog(container)
+        new_mappings_es = await conn.indices.get_mapping(index=real_index_name)
+        assert new_mappings_es[real_index_name]["mappings"]["properties"][
+            "foo_new_mapping"
+        ] == {"type": "text", "store": True}
+        for mapping in mappings_es[real_index_name]["mappings"]["properties"]:
+            assert mapping in new_mappings_es[real_index_name]["mappings"]["properties"]
+
+        # The same for settings
+        new_settings_es = await conn.indices.get_settings(index=real_index_name)
+        new_analysis_settings = new_settings_es[real_index_name]["settings"]["index"][
+            "analysis"
+        ]
+        assert new_analysis_settings["analyzer"]["common_analyzer2"]["filter"] == [
+            "asciifolding"
+        ]
+        # Let's make sure we can search and nothing is broken
+        resp, status = await requester(
+            "POST",
+            "/db/guillotina/",
+            data=json.dumps(
+                {
+                    "@type": "FooContent",
+                    "title": "Item",
+                    "id": "item",
+                    "item_keyword": "foo_kéyword",
+                    "item_text": "foo_item",
+                }
+            ),
+            headers={"X-Wait": "10"},
+        )
+        assert status == 201
+        await asyncio.sleep(2)
+        resp, status = await requester(
+            "GET",
+            "/db/guillotina/@search?item_keyword=foo_keyword&_metadata=item_keyword",
+            headers={"X-Wait": "10"},
+        )
+        assert status == 200
+        assert resp["items_total"] == 1

--- a/guillotina_elasticsearch/tests/test_package.py
+++ b/guillotina_elasticsearch/tests/test_package.py
@@ -26,6 +26,14 @@ class IFooContent(IResource):
     )
     item_text = TextLine()
 
+    index_field(
+        "item_bool",
+        type="boolean",
+        field="item_bool",
+        store=True,
+    )
+    item_bool = TextLine()
+
 
 @implementer(IFooContent)
 class FooContent(Resource):

--- a/guillotina_elasticsearch/tests/test_parser.py
+++ b/guillotina_elasticsearch/tests/test_parser.py
@@ -1,5 +1,3 @@
-from guillotina.directives import index_field
-from guillotina.interfaces import IContainer
 from guillotina.tests import utils as test_utils
 from guillotina_elasticsearch.parser import Parser
 from guillotina_elasticsearch.tests.utils import setup_txn_on_container
@@ -12,22 +10,26 @@ import pytest
 pytestmark = [pytest.mark.asyncio]
 
 
+@pytest.mark.app_settings(
+    {
+        "applications": [
+            "guillotina",
+            "guillotina_elasticsearch",
+            "guillotina_elasticsearch.tests.test_package",
+        ]
+    }
+)
 async def test_boolean_field(es_requester):
     async with es_requester as requester:
-
-        @index_field.with_accessor(IContainer, "foo_bool", type="boolean")
-        def index_bool(obj):
-            return True
-
         container, request, txn, tm = await setup_txn_on_container(requester)  # noqa
-        params = {"depth__gte": "1", "type_name": "IItem", "foo_bool": True}
+        params = {"depth__gte": "1", "type_name": "FooItem", "item_bool": True}
         parser = Parser(None, container)
         query = parser(params)
         qq = query["query"]["bool"]["must"]
         assert "_from" not in query
-        assert qq[1]["term"]["type_name"] == "IItem"
+        assert qq[1]["term"]["type_name"] == "FooItem"
         # https://www.elastic.co/guide/en/elasticsearch/reference/current/boolean.html
-        assert qq[2]["term"]["foo_bool"] == "true"
+        assert qq[2]["term"]["item_bool"] == "true"
 
 
 @pytest.mark.app_settings(


### PR DESCRIPTION
With this change, we allow to add new mappings and add/modify settings. This will be useful when indexing new fields. We will be able to index new mappings without having to delete the current index. Just bear in mind that mappings that exist can not be modified. 

Regarding the settings, we can modify/add new settings.
See: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html
https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html