### PR TITLE
adding multifield funcionality

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,9 @@
 7.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Adding multifields functionality, mutlifields param can be passed to
+  index_field. Useful when wanting to index the same field in
+  different ways
 
 
 7.0.2 (2022-11-23)

--- a/guillotina_elasticsearch/schema.py
+++ b/guillotina_elasticsearch/schema.py
@@ -78,6 +78,8 @@ def get_mappings(schemas=None, schema_info=False):
                 field_mapping["analyzer"] = catalog_info["analyzer"]
             if "normalizer" in catalog_info:
                 field_mapping["normalizer"] = catalog_info["normalizer"]
+            if "multifields" in catalog_info:
+                field_mapping["fields"] = catalog_info["multifields"]
             if schema_info:
                 if "_schemas" not in field_mapping:
                     field_mapping["_schemas"] = []

--- a/guillotina_elasticsearch/tests/test_package.py
+++ b/guillotina_elasticsearch/tests/test_package.py
@@ -23,6 +23,7 @@ class IFooContent(IResource):
         analyzer="common_analyzer",
         field="item_text",
         store=True,
+        multifields={"raw": {"type": "keyword"}},
     )
     item_text = TextLine()
 

--- a/guillotina_elasticsearch/tests/test_schema.py
+++ b/guillotina_elasticsearch/tests/test_schema.py
@@ -55,4 +55,5 @@ async def test_get_mappings_analyzers_normalizers(es_requester):
         "analyzer": "common_analyzer",
         "type": "text",
         "store": True,
+        "fields": {"raw": {"type": "keyword"}},
     }

--- a/guillotina_elasticsearch/tests/test_search.py
+++ b/guillotina_elasticsearch/tests/test_search.py
@@ -370,3 +370,26 @@ async def test_normalizer_analyzers_search(es_requester):
             headers={"X-Wait": "10"},
         )
         assert status == 200
+        resp, status = await requester(
+            "POST",
+            "/db/guillotina/",
+            data=json.dumps(
+                {
+                    "@type": "FooContent",
+                    "title": "Item",
+                    "id": "item2",
+                    "item_keyword": "foo_kéyword",
+                    "item_text": "another_text",
+                }
+            ),
+            headers={"X-Wait": "10"},
+        )
+        await asyncio.sleep(2)
+        # We can sort by the new multi field raw of item_text which is a keyword
+        resp, status = await requester(
+            "GET",
+            "/db/guillotina/@search?type_name=FooContent&_sort_asc=item_text.raw&_metadata=item_text",
+            headers={"X-Wait": "10"},
+        )
+        assert resp["items_total"] == 2
+        assert resp["items"][0]["item_text"] == "another_text"


### PR DESCRIPTION
Adding multifields functionality, mutlifields param can be passed to index_field. Useful when wanting to index the same field in different ways