### PR TITLE
not adding slash in __starts modifier if it is already there

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9, "3.10"]
         database: ["DUMMY", "postgres"]
     env:
       DATABASE: ${{ matrix.database }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 7.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Not adding a slash in the __start modifier of the parser if it is
+  already included from the base parser.
 
 
 7.0.3 (2023-02-08)

--- a/guillotina_elasticsearch/parser.py
+++ b/guillotina_elasticsearch/parser.py
@@ -165,7 +165,10 @@ def process_field(field, value):
     elif modifier == "starts":
         value_to_search = f"{value}*"
         if value != "/":
-            value_to_search = f"{value}/*"
+            if value.endswith("/"):
+                value_to_search = f"{value}*"
+            else:
+                value_to_search = f"{value}/*"
         return match_type, {"wildcard": {field: value_to_search}}
     else:
         logger.warn(
@@ -194,7 +197,6 @@ def process_query_level(params):
 class Parser(BaseParser):
     def __call__(self, params: typing.Dict) -> ParsedQueryInfo:
         query_info = super().__call__(params)
-
         metadata = query_info.get("metadata", [])
         if metadata:
             search_data = SEARCH_DATA_FIELDS + metadata


### PR DESCRIPTION
Due to https://github.com/plone/guillotina/commit/d7756f7f4caa11988cddbc86ceacd2f53b3c677b the @search endpoint is not giving any results as it is searching by context like: /context//*

Tested with guillotina 6.4.3 and older versions