### PR TITLE
removing elastic search from applications

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 7.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixing applications in __init__.py: Removing
+  guillotina_elasticsearch from it
 
 
 7.0.4 (2023-12-15)

--- a/guillotina_elasticsearch/__init__.py
+++ b/guillotina_elasticsearch/__init__.py
@@ -15,7 +15,6 @@ def default_refresh():
 
 
 app_settings = {
-    "applications": ["guillotina_elasticsearch"],
     "elasticsearch": {
         "bulk_size": 50,
         "refresh": "guillotina_elasticsearch.default_refresh",


### PR DESCRIPTION
I made a mistake when adding guillotina_elasticsearch in the applications. The previous commit should have gone to another repo. Sorry guys X)