### PR TITLE
getting items_total from conn.count

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,9 @@
 8.0.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Getting items_total from conn.count instead of getting it from the
+  hits of the result
+  [nilbacardit26]
 
 
 8.0.6 (2024-10-01)

--- a/guillotina_elasticsearch/utility.py
+++ b/guillotina_elasticsearch/utility.py
@@ -289,7 +289,9 @@ class ElasticSearchUtility(DefaultSearchUtility):
         index_settings = await conn.indices.get_settings(index=index)
         index_manager = get_adapter(container, IIndexManager)
         real_index_name = await index_manager.get_real_index_name()
-        max_result_window_value = index_settings[real_index_name]["settings"]["index"].get("max_result_window", 10000)
+        max_result_window_value = index_settings[real_index_name]["settings"][
+            "index"
+        ].get("max_result_window", 10000)
         if result.get("_shards", {}).get("failed", 0) > 0:
             logger.warning(f'Error running query: {result["_shards"]}')
             error_message = "Unknown"

--- a/guillotina_elasticsearch/utility.py
+++ b/guillotina_elasticsearch/utility.py
@@ -285,9 +285,7 @@ class ElasticSearchUtility(DefaultSearchUtility):
         if "size" in q["body"] and "size" in q:
             # ValueError: Received multiple values for 'size', specify parameters using either body or parameters, not both.
             del q["size"]
-        count = await conn.count(
-            index=index, body={"query": q["body"]["query"]}
-        )
+        count = await conn.count(index=index, body={"query": q["body"]["query"]})
         result: ObjectApiResponse = await conn.search(index=index, **q)
         if result.get("_shards", {}).get("failed", 0) > 0:
             logger.warning(f'Error running query: {result["_shards"]}')

--- a/guillotina_elasticsearch/utility.py
+++ b/guillotina_elasticsearch/utility.py
@@ -294,7 +294,7 @@ class ElasticSearchUtility(DefaultSearchUtility):
             raise QueryErrorException(reason=error_message)
         items = self._get_items_from_result(container, request, result)
         items_total = result["hits"]["total"]["value"]
-        if items_total > 10000:
+        if items_total == 10000:
             count = await conn.count(index=index, body={"query": q["body"]["query"]})
             items_total = count["count"]
         final = {"items_total": items_total, "items": items}

--- a/guillotina_elasticsearch/utility.py
+++ b/guillotina_elasticsearch/utility.py
@@ -285,6 +285,9 @@ class ElasticSearchUtility(DefaultSearchUtility):
         if "size" in q["body"] and "size" in q:
             # ValueError: Received multiple values for 'size', specify parameters using either body or parameters, not both.
             del q["size"]
+        count = await conn.count(
+            index=index, body={"query": q["body"]["query"]}
+        )
         result: ObjectApiResponse = await conn.search(index=index, **q)
         if result.get("_shards", {}).get("failed", 0) > 0:
             logger.warning(f'Error running query: {result["_shards"]}')
@@ -293,7 +296,7 @@ class ElasticSearchUtility(DefaultSearchUtility):
                 error_message = failure["reason"]
             raise QueryErrorException(reason=error_message)
         items = self._get_items_from_result(container, request, result)
-        items_total = result["hits"]["total"]["value"]
+        items_total = count["count"]
         final = {"items_total": items_total, "items": items}
 
         if "aggregations" in result:


### PR DESCRIPTION
Now, when the search returns more than 10k results, the items_total is always 10k. I do not know if there is a better way of doing this, but this works and seems okay to me