### PR TITLE
Multi match functionality

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 8.0.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Adding Multi match functionality. See test_search_multi_match for examples.
 
 
 8.0.14 (2025-08-05)

--- a/guillotina_elasticsearch/parser.py
+++ b/guillotina_elasticsearch/parser.py
@@ -205,9 +205,10 @@ def _collect_mm_groups(params):
             continue
         parts = k.split(".")
         key = parts[-1]
-        if key == "field":
-            groups.setdefault("field", [])
-            groups["field"].append(urllib.parse.unquote(v))
+        if key == "fields":
+            groups.setdefault("fields", [])
+            fields = urllib.parse.unquote(v)
+            groups["fields"] = fields.split(",")
         elif key == "query":
             groups["query"] = urllib.parse.unquote(v)
         else:
@@ -221,12 +222,12 @@ def _collect_mm_groups(params):
 def _mm_to_clause(g):
     mm = {
         "query": g["query"],
-        "fields": g.get("field", []),
+        "fields": g.get("fields", []),
         "type": g.get("type", "best_fields"),
         "operator": g.get("op", "and"),
     }
-    if "fuzziness" in g:
-        mm["fuzziness"] = g["fuzziness"]
+    if "fz" in g:
+        mm["fuzziness"] = g["fz"]
     if "analyzer" in g:
         mm["analyzer"] = g["analyzer"]
     if "slop" in g:
@@ -296,5 +297,4 @@ class Parser(BaseParser):
         query["sort"].append({"_id": "desc"})
         query["from"] = query_info.get("_from", 0)
         query["size"] = query_info.get("size", 0)
-        __import__("pdb").set_trace()
         return typing.cast(ParsedQueryInfo, query)

--- a/guillotina_elasticsearch/parser.py
+++ b/guillotina_elasticsearch/parser.py
@@ -207,8 +207,9 @@ def _collect_mm_groups(params):
         key = parts[-1]
         if key == "field":
             groups.setdefault("field", [])
-            value = urllib.parse.unquote(v)
-            groups["field"].append(value)
+            groups["field"].append(urllib.parse.unquote(v))
+        elif key == "query":
+            groups["query"] = urllib.parse.unquote(v)
         else:
             groups[key] = v
         # Let's remove the multi match keys to not interfere the logic
@@ -295,4 +296,5 @@ class Parser(BaseParser):
         query["sort"].append({"_id": "desc"})
         query["from"] = query_info.get("_from", 0)
         query["size"] = query_info.get("size", 0)
+        __import__("pdb").set_trace()
         return typing.cast(ParsedQueryInfo, query)

--- a/guillotina_elasticsearch/parser.py
+++ b/guillotina_elasticsearch/parser.py
@@ -270,21 +270,13 @@ class Parser(BaseParser):
         else:
             search_data = SEARCH_DATA_FIELDS
         groups = _collect_mm_groups(query_info["params"])
-        bool_q = {"must": [], "should": [], "must_not": [], "minimum_should_match": 1}
-        bool_q.update(
-            process_query_level(query_info["params"])
-        )  # your existing builder
-
+        bool_q = process_query_level(query_info["params"])
         if groups != {}:
             clause, mode = _mm_to_clause(groups)
             if mode == "should":
-                bool_q["should"].append(clause)
+                bool_q.setdefault("should", []).append(clause)
             else:
-                bool_q["must"].append(clause)
-        if not bool_q["should"]:
-            bool_q.pop("should", None)
-            bool_q.pop("minimum_should_match", None)
-
+                bool_q.setdefault("must", []).append(clause)
         query = {
             "stored_fields": search_data,
             "query": {"bool": bool_q},

--- a/guillotina_elasticsearch/tests/conftest.py
+++ b/guillotina_elasticsearch/tests/conftest.py
@@ -1,12 +1,12 @@
 from pytest_docker_fixtures import images
 
 
-image_version_8 = "8.12.0-debian-11-r2"
-image_version_7 = "7.17.16-debian-11-r3"  # noqa
+image_version_8 = "8.12.0"
+image_version_7 = "7.17.16"  # noqa
 
 images.configure(
     name="elasticsearch",
-    full=f"bitnami/elasticsearch:{image_version_8}",
+    full=f"bitnamilegacy/elasticsearch:{image_version_8}",
     max_wait_s=90,
     env={"ELASTICSEARCH_ENABLE_SECURITY": "false", "ELASTICSEARCH_HEAP_SIZE": "1g"},
 )

--- a/guillotina_elasticsearch/tests/test_package.py
+++ b/guillotina_elasticsearch/tests/test_package.py
@@ -28,6 +28,17 @@ class IFooContent(IResource):
     )
     item_text = TextLine()
 
+    index_field(
+        "item_text",
+        type="text",
+        analyzer="common_analyzer",
+        field="item_text_2",
+        store=True,
+        multifields={"raw": {"type": "keyword"}},
+        search_analyzer="standard",
+    )
+    item_text_2 = TextLine()
+
 
 @implementer(IFooContent)
 class FooContent(Resource):

--- a/guillotina_elasticsearch/tests/test_search.py
+++ b/guillotina_elasticsearch/tests/test_search.py
@@ -577,3 +577,63 @@ async def test_search_fields_not_exists(es_requester):
         expected_results_id = ["item3", "item4", "item5"]
         for item in resp["items"]:
             assert item["id"] in expected_results_id
+
+
+@pytest.mark.app_settings(
+    {
+        "applications": [
+            "guillotina",
+            "guillotina_elasticsearch",
+            "guillotina_elasticsearch.tests.test_package",
+        ]
+    }
+)
+async def test_search_multi_field(es_requester):
+    async with es_requester as requester:
+        # Let's index a document without item_keyword
+        resp, status = await requester(
+            "POST",
+            "/db/guillotina/",
+            data=json.dumps(
+                {
+                    "@type": "FooContent",
+                    "title": "Item",
+                    "id": "item",
+                    "item_text": "This is an item text",
+                    "item_text_2": "This is another text refering the item",
+                }
+            ),
+            headers={"X-Wait": "10"},
+        )
+        assert status == 201
+        await asyncio.sleep(2)
+        resp, status = await requester(
+            "GET",
+            "/db/guillotina/@search?type_name=FooContent&_metadata=*&mm.0.field=item_text%5E2&mm.1.field=item_text_2%5E3&mm.type=best_fields&mm.fuzziness=AUTO&mm.query=text%20item",
+        )
+        assert status == 200
+        assert resp["items_total"] == 1
+
+        # Fuziness auto allow two edits for texts larger than 5 characters
+        resp, status = await requester(
+            "GET",
+            "/db/guillotina/@search?type_name=FooContent&_metadata=*&mm.0.field=item_text%5E2&mm.1.field=item_text_2%5E3&mm.type=best_fields&mm.fuzziness=AUTO&mm.query=taxt%20atem",
+        )
+        assert status == 200
+        assert resp["items_total"] == 1
+
+        # Fuziness auto allow two edits for texts larger than 5 characters. If more edits, 0 results
+        resp, status = await requester(
+            "GET",
+            "/db/guillotina/@search?type_name=FooContent&_metadata=*&mm.0.field=item_text%5E2&mm.1.field=item_text_2%5E3&mm.type=best_fields&mm.fuzziness=AUTO&mm.query=tart%20atem",
+        )
+        assert status == 200
+        assert resp["items_total"] == 0
+
+        # We can use cross_fields for instance. Fuziness not allowed
+        resp, status = await requester(
+            "GET",
+            "/db/guillotina/@search?type_name=FooContent&_metadata=*&mm.0.field=item_text%5E2&mm.1.field=item_text_2%5E3&mm.type=cross_fields&mm.query=item",
+        )
+        assert status == 200
+        assert resp["items_total"] == 1

--- a/guillotina_elasticsearch/tests/test_search.py
+++ b/guillotina_elasticsearch/tests/test_search.py
@@ -588,7 +588,7 @@ async def test_search_fields_not_exists(es_requester):
         ]
     }
 )
-async def test_search_multi_field(es_requester):
+async def test_search_multi_match(es_requester):
     async with es_requester as requester:
         # Let's index a document without item_keyword
         resp, status = await requester(

--- a/guillotina_elasticsearch/tests/test_search.py
+++ b/guillotina_elasticsearch/tests/test_search.py
@@ -609,23 +609,22 @@ async def test_search_multi_field(es_requester):
         await asyncio.sleep(2)
         resp, status = await requester(
             "GET",
-            "/db/guillotina/@search?type_name=FooContent&_metadata=*&mm.0.field=item_text%5E2&mm.1.field=item_text_2%5E3&mm.type=best_fields&mm.fuzziness=AUTO&mm.query=text%20item",
+            "/db/guillotina/@search?type_name=FooContent&_metadata=*&mm.fields=item_text%5E2%2Citem_text_2%5E3&mm.type=best_fields&mm.fz=AUTO&mm.query=text%20item",
         )
         assert status == 200
         assert resp["items_total"] == 1
 
-        # Fuziness auto allow two edits for texts larger than 5 characters
+        # Fuziness auto allow two edits for words larger than 5 characters
         resp, status = await requester(
             "GET",
-            "/db/guillotina/@search?type_name=FooContent&_metadata=*&mm.0.field=item_text%5E2&mm.1.field=item_text_2%5E3&mm.type=best_fields&mm.fuzziness=AUTO&mm.query=taxt%20atem",
+            "/db/guillotina/@search?type_name=FooContent&_metadata=*&mm.fields=item_text%5E2%2Citem_text_2%5E3&mm.type=best_fields&mm.fz=AUTO&mm.query=taxt%20atem",
         )
         assert status == 200
         assert resp["items_total"] == 1
-
-        # Fuziness auto allow two edits for texts larger than 5 characters. If more edits, 0 results
+        # Fuziness auto allow two edits for words larger than 5 characters
         resp, status = await requester(
             "GET",
-            "/db/guillotina/@search?type_name=FooContent&_metadata=*&mm.0.field=item_text%5E2&mm.1.field=item_text_2%5E3&mm.type=best_fields&mm.fuzziness=AUTO&mm.query=tart%20atem",
+            "/db/guillotina/@search?type_name=FooContent&_metadata=*&mm.fields=item_text%5E2%2Citem_text_2%5E3&mm.type=best_fields&mm.fz=AUTO&mm.query=tart%20atem",
         )
         assert status == 200
         assert resp["items_total"] == 0
@@ -633,7 +632,7 @@ async def test_search_multi_field(es_requester):
         # We can use cross_fields for instance. Fuziness not allowed
         resp, status = await requester(
             "GET",
-            "/db/guillotina/@search?type_name=FooContent&_metadata=*&mm.0.field=item_text%5E2&mm.1.field=item_text_2%5E3&mm.type=cross_fields&mm.query=item",
+            "/db/guillotina/@search?type_name=FooContent&_metadata=*&mm.fields=item_text%5E2%2Citem_text_2%5E3&mm.type=cross_fields&mm.query=item",
         )
         assert status == 200
         assert resp["items_total"] == 1


### PR DESCRIPTION
I slightly modified the parser to use multi_match clauses. We usually need to perform more complicated queries that involve a multi_match query with fuzziness. 

With this we can do like:

```
resp, status = await requester(
            "GET",
            "/db/guillotina/@search?type_name=FooContent&_metadata=*&mm.fields=item_text%5E2%2Citem_text_2%5E3&mm.type=best_fields&mm.fz=AUTO&mm.query=taxt%20atem",
        )
        assert status == 200
        assert resp["items_total"] == 1
```
That would be translated to:

```
"query": {
            "bool": {
                "must": [
                    {"term": {"type_name": "FooContent"}},
                    {"range": {"depth": {"gte": 1}}},
                    {"wildcard": {"path": "/*"}},
                    {
                        "multi_match": {
                            "fields": ["item_text^2", "item_text_2^3"],
                            "fuzziness": "AUTO",
                            "operator": "and",
                            "query": "taxt atem",
                            "type": "best_fields",
                        }
                    },
                ],
                "must_not": [],
            }
        },
```

Specifying the fields in the mm.fields with an encoded boost, and fields separated by encoded comas. All the types of multi_match are supported and by default best_fields is used. We can use fuzziness, operator (by default and), boost, tie, slop, analyzer, type (by default best fields). We can pass mode as well (by default must) to choose whether the multi_match clause to be in must or should clause.

Let me know what you think.

Reference: https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-multi-match-query