### PR TITLE
fixing match_type in __not=null

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,9 @@
 -------------------
 
 - Using and fixing match_type in __not=null clauses.
+- Do not fail with a 500 if a field in an __or cluase is not indexed
   [nilbacardit26]
+
 
 
 8.0.16 (2025-11-10)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 8.0.17 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Using and fixing match_type in __not=null clauses.
+  [nilbacardit26]
 
 
 8.0.16 (2025-11-10)

--- a/guillotina_elasticsearch/parser.py
+++ b/guillotina_elasticsearch/parser.py
@@ -175,7 +175,7 @@ def process_field(field, value):
         if value and value != "null":
             return "must_not", {term_keyword: {field: value}}
         elif value == "null":
-            return "must", {"exists": {"field": field}}
+            return match_type, {"exists": {"field": field}}
     elif modifier == "in" and _type in ("text", "searchabletext"):
         # The value list can be inside the field
         return match_type, {"match": {field: value}}

--- a/guillotina_elasticsearch/parser.py
+++ b/guillotina_elasticsearch/parser.py
@@ -56,9 +56,12 @@ def process_compound_field(field, value, operator):
     query = {"must": [], "should": [], "minimum_should_match": 1, "must_not": []}
     for kk, vv in parsed_value:
         if operator == "or":
-            match_type, sub_part = process_field(kk + "__should", vv)
+            result = process_field(kk + "__should", vv)
         else:
-            match_type, sub_part = process_field(kk, vv)
+            result = process_field(kk, vv)
+        if result is None:
+            continue
+        match_type, sub_part = result
         query[match_type].append(sub_part)
 
     if len(query["should"]) == 0:

--- a/guillotina_elasticsearch/tests/fixtures.py
+++ b/guillotina_elasticsearch/tests/fixtures.py
@@ -94,14 +94,14 @@ class ESRequester(ContainerRequesterAsyncContextManager):
 
         if os.environ.get("TESTING", "") == "jenkins":
             if "elasticsearch" in app_settings:
-                app_settings["elasticsearch"]["connection_settings"][
-                    "hosts"
-                ] = [  # noqa
-                    "{}:{}".format(
-                        getattr(elasticsearch, "host", "localhost"),
-                        getattr(elasticsearch, "port", "9200"),
-                    )
-                ]
+                app_settings["elasticsearch"]["connection_settings"]["hosts"] = (
+                    [  # noqa
+                        "{}:{}".format(
+                            getattr(elasticsearch, "host", "localhost"),
+                            getattr(elasticsearch, "port", "9200"),
+                        )
+                    ]
+                )
         return await super().__aenter__()
 
 

--- a/guillotina_elasticsearch/tests/fixtures.py
+++ b/guillotina_elasticsearch/tests/fixtures.py
@@ -94,14 +94,14 @@ class ESRequester(ContainerRequesterAsyncContextManager):
 
         if os.environ.get("TESTING", "") == "jenkins":
             if "elasticsearch" in app_settings:
-                app_settings["elasticsearch"]["connection_settings"]["hosts"] = (
-                    [  # noqa
-                        "{}:{}".format(
-                            getattr(elasticsearch, "host", "localhost"),
-                            getattr(elasticsearch, "port", "9200"),
-                        )
-                    ]
-                )
+                app_settings["elasticsearch"]["connection_settings"][
+                    "hosts"
+                ] = [  # noqa
+                    "{}:{}".format(
+                        getattr(elasticsearch, "host", "localhost"),
+                        getattr(elasticsearch, "port", "9200"),
+                    )
+                ]
         return await super().__aenter__()
 
 

--- a/guillotina_elasticsearch/tests/test_parser.py
+++ b/guillotina_elasticsearch/tests/test_parser.py
@@ -83,6 +83,23 @@ async def test_parser_term_and_terms(dummy_guillotina):
     assert query["size"] == 10
 
 
+async def test_parser_or_clause_with_not_null_uses_should(dummy_guillotina):
+    content = test_utils.create_content()
+    parser = Parser(None, content)
+    query = parser({"type_name": "Person", "__or": "title__not=null%26id=null"})
+    bool_query = query["query"]["bool"]
+    or_clause = next(
+        item["bool"]
+        for item in bool_query["must"]
+        if isinstance(item, dict)
+        and "bool" in item
+        and item["bool"].get("minimum_should_match") == 1
+        and item["bool"].get("should")
+    )
+    assert {"exists": {"field": "title"}} in or_clause["should"]
+    assert {"exists": {"field": "title"}} not in or_clause.get("must", [])
+
+
 async def test_parser_or_operator(es_requester):
     async with es_requester as requester:
         container, request, txn, tm = await setup_txn_on_container(requester)  # noqa

--- a/guillotina_elasticsearch/tests/test_parser.py
+++ b/guillotina_elasticsearch/tests/test_parser.py
@@ -86,7 +86,7 @@ async def test_parser_term_and_terms(dummy_guillotina):
 async def test_parser_or_clause_with_not_null_uses_should(dummy_guillotina):
     content = test_utils.create_content()
     parser = Parser(None, content)
-    query = parser({"type_name": "Person", "__or": "title__not=null%26id=null"})
+    query = parser({"type_name": "Person", "__or": "type_name__not=null%26id=null"})
     bool_query = query["query"]["bool"]
     or_clause = next(
         item["bool"]
@@ -96,8 +96,27 @@ async def test_parser_or_clause_with_not_null_uses_should(dummy_guillotina):
         and item["bool"].get("minimum_should_match") == 1
         and item["bool"].get("should")
     )
-    assert {"exists": {"field": "title"}} in or_clause["should"]
-    assert {"exists": {"field": "title"}} not in or_clause.get("must", [])
+    assert {"exists": {"field": "type_name"}} in or_clause["should"]
+    assert {"exists": {"field": "type_name"}} not in or_clause.get("must", [])
+
+
+async def test_parser_or_clause_ignores_unknown_fields(dummy_guillotina):
+    content = test_utils.create_content()
+    parser = Parser(None, content)
+    query = parser(
+        {"type_name": "Person", "__or": "type_name__not=null%26ghost_field=null"}
+    )
+    bool_query = query["query"]["bool"]
+    or_clause = next(
+        item["bool"]
+        for item in bool_query["must"]
+        if isinstance(item, dict)
+        and "bool" in item
+        and item["bool"].get("minimum_should_match") == 1
+        and item["bool"].get("should")
+    )
+    assert {"exists": {"field": "type_name"}} in or_clause["should"]
+    assert len(or_clause["should"]) == 1
 
 
 async def test_parser_or_operator(es_requester):


### PR DESCRIPTION
Fixing match_type, must was hardcoded when using __not=null

